### PR TITLE
Avoid monitoring processes without a deadline set in exit_after/1

### DIFF
--- a/lib/deadline.ex
+++ b/lib/deadline.ex
@@ -38,9 +38,14 @@ defmodule Deadline do
   Accepts a callback that will be executed prior to exiting the calling process.
   """
   def exit_after(before_exit \\ nil) do
-    case Deadline.MonitorSupervisor.start_child(self(), time_remaining(), before_exit) do
-      {:ok, _pid} -> :ok
-      {:error, _error} -> :error
+    case time_remaining() do
+      :infinity -> :ok
+
+      time_remaining ->
+        case Deadline.MonitorSupervisor.start_child(self(), time_remaining, before_exit) do
+          {:ok, _pid} -> :ok
+          {:error, _error} -> :error
+        end
     end
   end
 


### PR DESCRIPTION
Deadline will currently attempt to start a monitoring process if `exit_after/1` is called in a process without a deadline set. This will cause a crash to happen in `Deadline.Monitor` on `Process.send_after(self(), :exit_monitored_process, :infinity)`. Ultimately, this wont affect the critical path but is unnecessary work.